### PR TITLE
fix profile-route for application not on '/' (web-root)

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -16,7 +16,7 @@
                         {{ __('Users') }}
                     </x-nav-link>
                     {{-- Task: this "Profile" link should be visible only to logged-in users --}}
-                    <x-nav-link href="/profile" :active="request()->routeIs('profile.show')">
+                    <x-nav-link :href="route('profile.show')" :active="request()->routeIs('profile.show')">
                         {{ __('Profile') }}
                     </x-nav-link>
                 </div>

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -34,11 +34,11 @@ class AuthenticationTest extends TestCase
     public function test_profile_link_is_invisible_in_public()
     {
         $response = $this->get('/');
-        $this->assertStringNotContainsString('href="/profile"', $response->getContent());
+        $this->assertStringNotContainsString('href="'.route('profile.show').'"', $response->getContent());
 
         $user = User::factory()->create();
         $response = $this->actingAs($user)->get('/');
-        $this->assertStringContainsString('href="/profile"', $response->getContent());
+        $this->assertStringContainsString('href="'.route('profile.show').'"', $response->getContent());
     }
 
     public function test_profile_fields_are_visible()


### PR DESCRIPTION
 fix profile-route for application not on '/' (web-root), e.g. if application is on '/testapp' then the profile-route is '/testapp/profile'.

On homestead the full URL in this case is 'http://homestead.test/testapp/profile'.

Perhaps, this is useful for others.

Best regards

Carsten